### PR TITLE
Fetch the first response before starting the stream

### DIFF
--- a/pkg/http/sse.go
+++ b/pkg/http/sse.go
@@ -146,6 +146,11 @@ func (h sseHandler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	response, ok := h.streamAdapter.GetResponse(w, r)
+	if !ok {
+		return
+	}
+
 	responsesChan := make(chan interface{})
 
 	go func() {
@@ -153,11 +158,6 @@ func (h sseHandler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 			h.logger.Trace("Closing SSE handler", nil)
 			close(responsesChan)
 		}()
-
-		response, ok := h.streamAdapter.GetResponse(w, r)
-		if !ok {
-			return
-		}
 
 		responsesChan <- response
 

--- a/pkg/http/sse_test.go
+++ b/pkg/http/sse_test.go
@@ -92,6 +92,18 @@ func TestSSE(t *testing.T) {
 		require.Equal(t, 500, resp.StatusCode)
 	})
 
+	t.Run("event_stream_error_request", func(t *testing.T) {
+		req, err := netHTTP.NewRequest("GET", server.URL+"/posts/"+notExistingID, nil)
+		require.NoError(t, err)
+
+		req.Header.Add("Accept", "text/event-stream")
+
+		resp, err := netHTTP.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		require.Equal(t, 500, resp.StatusCode)
+	})
+
 	t.Run("event_stream_no_updates", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()


### PR DESCRIPTION
This allows returning errors, such as 404 at the beginning of the request