### PR TITLE
Do not panic on a wrong metadata or invalid payload on Subscribe()

### DIFF
--- a/pkg/http/subscriber.go
+++ b/pkg/http/subscriber.go
@@ -116,10 +116,6 @@ func (s *Subscriber) Subscribe(ctx context.Context, url string) (<-chan *message
 	s.config.Router.Post(url, func(w http.ResponseWriter, r *http.Request) {
 		msg, err := s.config.UnmarshalMessageFunc(url, r)
 
-		ctx, cancelCtx := context.WithCancel(ctx)
-		msg.SetContext(ctx)
-		defer cancelCtx()
-
 		if err != nil {
 			s.logger.Info("Cannot unmarshal message", baseLogFields.Add(watermill.LogFields{"err": err}))
 			w.WriteHeader(http.StatusBadRequest)
@@ -130,6 +126,11 @@ func (s *Subscriber) Subscribe(ctx context.Context, url string) (<-chan *message
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+
+		ctx, cancelCtx := context.WithCancel(ctx)
+		msg.SetContext(ctx)
+		defer cancelCtx()
+
 		logFields := baseLogFields.Add(watermill.LogFields{"message_uuid": msg.UUID})
 
 		s.logger.Trace("Sending msg", logFields)


### PR DESCRIPTION
### What

Do not panic when `UnmarshalMessageFunc()` returns an error and handle invalid payloads and wrong metadata correctly.

### Why

At the moment `UnmarshalMessageFunc()` may run into runtime error and panic, because it tries to call `msg.SetContext()` even though the message is `nil pointer`:

```go
// pkg/http/subscriber.go:
// ...
s.config.Router.Post(url, func(w http.ResponseWriter, r *http.Request) {
	msg, err := s.config.UnmarshalMessageFunc(url, r)

	ctx, cancelCtx := context.WithCancel(ctx)
	msg.SetContext(ctx)
	defer cancelCtx()
// ...
```

Subscriber logs:
```
2020/11/10 15:54:53 http: panic serving [::1]:64485: runtime error: invalid memory address or nil pointer dereference
goroutine 34 [running]:
net/http.(*conn).serve.func1(0xc000098000)
        /usr/local/go/src/net/http/server.go:1801 +0x147
panic(0x1381720, 0x163df60)
        /usr/local/go/src/runtime/panic.go:975 +0x3e9
github.com/ThreeDotsLabs/watermill/message.(*Message).SetContext(...)
        /../go/pkg/mod/github.com/!three!dots!labs/watermill@v1.1.0/message/message.go:173
github.com/ThreeDotsLabs/watermill-http/pkg/http.(*Subscriber).Subscribe.func1(0x1460c40, 0xc0000c2000, 0xc0000b6100)
        /../watermill-http/pkg/http/subscriber.go:120 +0x102
net/http.HandlerFunc.ServeHTTP(0xc0001d4880, 0x1460c40, 0xc0000c2000, 0xc0000b6100)
        /usr/local/go/src/net/http/server.go:2042 +0x44
github.com/go-chi/chi.(*Mux).routeHTTP(0xc00019e4e0, 0x1460c40, 0xc0000c2000, 0xc0000b6100)
        /../go/pkg/mod/github.com/go-chi/chi@v4.0.2+incompatible/mux.go:425 +0x28b
net/http.HandlerFunc.ServeHTTP(0xc000193030, 0x1460c40, 0xc0000c2000, 0xc0000b6100)
        /usr/local/go/src/net/http/server.go:2042 +0x44
github.com/go-chi/chi.(*Mux).ServeHTTP(0xc00019e4e0, 0x1460c40, 0xc0000c2000, 0xc0000b6000)
        /../go/pkg/mod/github.com/go-chi/chi@v4.0.2+incompatible/mux.go:82 +0x2d1
net/http.serverHandler.ServeHTTP(0xc000218000, 0x1460c40, 0xc0000c2000, 0xc0000b6000)
        /usr/local/go/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc000098000, 0x1461600, 0xc0000ae000)
        /usr/local/go/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2969 +0x36c
```

### Dependencies

_None_

### Risk and impact

Currently, only one workaround is to implement a custom `UnmarshalMessageFunc()` and never return `nil` for `*message.Message` which does not seem right and brings some magic behavior. By applying this PR no need to do any workarounds, and the package works as expected.