### PR TITLE
Add http/2 support

### DIFF
--- a/pkg/http/pubsub_test.go
+++ b/pkg/http/pubsub_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message/subscriber"
 	"github.com/ThreeDotsLabs/watermill/pubsub/tests"
+	"github.com/go-chi/chi"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
@@ -21,18 +22,39 @@ import (
 func createPubSub(t *testing.T) (*http.Publisher, *http.Subscriber) {
 	logger := watermill.NewStdLogger(true, true)
 
+	subscriberConf := http.SubscriberConfig{
+		NewHTTPServerFunc: func(addr string, router chi.Router) *nethttp.Server {
+			protocols := &nethttp.Protocols{}
+			protocols.SetUnencryptedHTTP2(true)
+			return &nethttp.Server{
+				Addr:      addr,
+				Handler:   router,
+				Protocols: protocols,
+			}
+		},
+	}
 	// use any free port to allow parallel tests
-	sub, err := http.NewSubscriber(":0", http.SubscriberConfig{}, logger)
+	sub, err := http.NewSubscriber(":0", subscriberConf, logger)
 	require.NoError(t, err)
 
 	publisherConf := http.PublisherConfig{
 		MarshalMessageFunc: http.DefaultMarshalMessageFunc,
+		Client:             createClient(),
 	}
-
 	pub, err := http.NewPublisher(publisherConf, logger)
 	require.NoError(t, err)
 
 	return pub, sub
+}
+
+func createClient() *nethttp.Client {
+	protocols := &nethttp.Protocols{}
+	protocols.SetUnencryptedHTTP2(true)
+	return &nethttp.Client{
+		Transport: &nethttp.Transport{
+			Protocols: protocols,
+		},
+	}
 }
 
 func TestPublishSubscribe(t *testing.T) {
@@ -75,7 +97,7 @@ func TestHttpPubSub(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set(http.HeaderMetadata, "invalid_metadata")
 
-		resp, err := nethttp.DefaultClient.Do(req)
+		resp, err := createClient().Do(req)
 		require.NoError(t, err)
 
 		require.Equal(t, nethttp.StatusBadRequest, resp.StatusCode)
@@ -126,7 +148,7 @@ func TestHttpSubStatusCode(t *testing.T) {
 		req, err := nethttp.NewRequest(nethttp.MethodPost, fmt.Sprintf("http://%s/test", sub.Addr()), nil)
 		require.NoError(t, err)
 
-		resp, err := nethttp.DefaultClient.Do(req)
+		resp, err := createClient().Do(req)
 		require.NoError(t, err)
 
 		require.Equal(t, nethttp.StatusForbidden, resp.StatusCode)

--- a/pkg/http/subscriber.go
+++ b/pkg/http/subscriber.go
@@ -40,9 +40,16 @@ func DefaultUnmarshalMessageFunc(topic string, req *http.Request) (*message.Mess
 	return msg, nil
 }
 
+type NewHTTPServerFunc func(addr string, router chi.Router) *http.Server
+
+func DefaultNewHTTPServerFunc(addr string, router chi.Router) *http.Server {
+	return &http.Server{Addr: addr, Handler: router}
+}
+
 type SubscriberConfig struct {
 	Router               chi.Router
 	UnmarshalMessageFunc UnmarshalMessageFunc
+	NewHTTPServerFunc    NewHTTPServerFunc
 }
 
 func (s *SubscriberConfig) setDefaults() {
@@ -52,6 +59,10 @@ func (s *SubscriberConfig) setDefaults() {
 
 	if s.UnmarshalMessageFunc == nil {
 		s.UnmarshalMessageFunc = DefaultUnmarshalMessageFunc
+	}
+
+	if s.NewHTTPServerFunc == nil {
+		s.NewHTTPServerFunc = DefaultNewHTTPServerFunc
 	}
 }
 
@@ -79,7 +90,7 @@ type Subscriber struct {
 // logger is Watermill's logger.
 func NewSubscriber(addr string, config SubscriberConfig, logger watermill.LoggerAdapter) (*Subscriber, error) {
 	config.setDefaults()
-	s := &http.Server{Addr: addr, Handler: config.Router}
+	server := config.NewHTTPServerFunc(addr, config.Router)
 
 	if logger == nil {
 		logger = watermill.NopLogger{}
@@ -87,7 +98,7 @@ func NewSubscriber(addr string, config SubscriberConfig, logger watermill.Logger
 
 	return &Subscriber{
 		config:             config,
-		server:             s,
+		server:             server,
 		logger:             logger,
 		outputChannels:     make([]chan *message.Message, 0),
 		outputChannelsLock: &sync.Mutex{},


### PR DESCRIPTION
### Motivation / Background

The current subscriber implementation directly constructs a net/http.Server, which tightly couples the subscriber to a single HTTP server implementation.

While this works well today, it makes it harder to extend the subscriber to support alternative server setups and customise server behaviour without modifying core subscriber logic.

### Details

This PR introduces a small abstraction to decouple server creation while keeping backward compatibility.

### Alternative approaches considered (if applicable)

Exposing http.Server directly in config. Avoided because 
1. Server address currently passed in subscriber constructor would be duplicated in server construction causing confusion. Avoiding this would break backward compatibility.
2. Ownership of net/http.Server becomes unclear.

### Checklist

- [x] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
