### PR TITLE
fix(sse): clone chi RouteContext for streaming goroutine

### DIFF
--- a/pkg/http/sse.go
+++ b/pkg/http/sse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"github.com/pkg/errors"
 
@@ -167,6 +168,12 @@ func (h sseHandler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// chi pools its *Context and resets it after ServeHTTP returns. Our
+	// goroutine outlives the handler in some paths (e.g. responder exiting
+	// on ctx.Done()), so a later request can race the goroutine's
+	// chi.URLParam calls on the reset Context. Detach a copy now.
+	streamReq := requestWithDetachedChiContext(r)
+
 	responsesChan := make(chan interface{})
 
 	go func() {
@@ -188,7 +195,7 @@ func (h sseHandler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 
 				msg.Ack()
 
-				nextResponse, ok := h.streamAdapter.NextStreamResponse(r, msg)
+				nextResponse, ok := h.streamAdapter.NextStreamResponse(streamReq, msg)
 
 				select {
 				case <-r.Context().Done():
@@ -210,4 +217,25 @@ func (h sseHandler) handleEventStream(w http.ResponseWriter, r *http.Request) {
 		marshaler: h.config.Marshaler,
 	}
 	responder.Respond(w, r, responsesChan)
+}
+
+// requestWithDetachedChiContext returns a copy of r whose context holds a
+// fresh *chi.Context populated from the request's routing context. Used to
+// safely access chi.URLParam from goroutines that may outlive ServeHTTP,
+// because chi pools and resets *chi.Context after the handler returns.
+func requestWithDetachedChiContext(r *http.Request) *http.Request {
+	rctx := chi.RouteContext(r.Context())
+	if rctx == nil {
+		return r
+	}
+
+	copied := chi.NewRouteContext()
+	copied.URLParams.Keys = append(copied.URLParams.Keys, rctx.URLParams.Keys...)
+	copied.URLParams.Values = append(copied.URLParams.Values, rctx.URLParams.Values...)
+	copied.RoutePatterns = append(copied.RoutePatterns, rctx.RoutePatterns...)
+	copied.RoutePath = rctx.RoutePath
+	copied.RouteMethod = rctx.RouteMethod
+	copied.Routes = rctx.Routes
+
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, copied))
 }


### PR DESCRIPTION
### Motivation / Background

  `TestSSE/event_stream_updated_after_context_closed` fails under `-race`.

  chi pools `*chi.Context` and `Reset()`s it after `ServeHTTP` returns.
  The SSE streaming goroutine can outlive the handler and calls
  `StreamAdapter.NextStreamResponse(r, msg)`, where adapters typically
  read `chi.URLParam(r, ...)`. A later request reusing the pooled
  `*chi.Context` races that read.

  ### Details

  Before launching the goroutine, copy the request's `*chi.Context`
  (URLParams, RoutePatterns, RoutePath, RouteMethod, Routes) into a new
  one and attach it via `r.WithContext`. The goroutine uses this
  detached request for `NextStreamResponse`, so `chi.URLParam` survives
  chi's pool reset.

```
--- PASS: TestHttpPubSub (0.06s)
    --- PASS: TestHttpPubSub/publish_a_message_with_invalid_metadata (0.00s)
    --- PASS: TestHttpPubSub/publish_correct_simple_messages (0.05s)
=== RUN   TestHttpSubStatusCode
=== RUN   TestHttpSubStatusCode/response_with_custom_http_status_code
[watermill] 2026/05/20 19:46:49.920172 subscriber.go:147:       level=TRACE msg="Sending msg" message_uuid= provider=http url=/test
[watermill] 2026/05/20 19:46:49.920206 subscriber.go:150:       level=TRACE msg="Waiting for ACK" message_uuid= provider=http url=/test
[watermill] 2026/05/20 19:46:49.920246 subscriber.go:158:       level=TRACE msg="Message nacked" err=<nil> http_status_code=403 message_uuid= provider=http url=/test
--- PASS: TestHttpSubStatusCode (0.01s)
    --- PASS: TestHttpSubStatusCode/response_with_custom_http_status_code (0.00s)
=== RUN   TestSSE
=== RUN   TestSSE/generic_request
=== RUN   TestSSE/error_request
=== RUN   TestSSE/event_stream_error_request
=== RUN   TestSSE/event_stream_no_updates
=== RUN   TestSSE/event_stream_updated
=== RUN   TestSSE/event_stream_updated_after_context_closed
--- PASS: TestSSE (2.46s)
    --- PASS: TestSSE/generic_request (0.00s)
    --- PASS: TestSSE/error_request (0.00s)
    --- PASS: TestSSE/event_stream_error_request (0.00s)
    --- PASS: TestSSE/event_stream_no_updates (1.00s)
    --- PASS: TestSSE/event_stream_updated (1.00s)
    --- PASS: TestSSE/event_stream_updated_after_context_closed (0.45s)
PASS
ok      github.com/ThreeDotsLabs/watermill-http/v2/pkg/http     3.541s
```